### PR TITLE
Quote special chars in inserted filename

### DIFF
--- a/anyframe-functions/actions/anyframe-action-insert-quoted
+++ b/anyframe-functions/actions/anyframe-action-insert-quoted
@@ -1,0 +1,24 @@
+function _anyframe-action-insert-quoted()
+{
+  if zle; then
+    LBUFFER+="${(q)*}"
+    CURSOR=$#LBUFFER
+    # redisplay the command line
+    zle -R -c
+  else
+    print -z "$*"
+  fi
+}
+
+local selected_items
+selected_items="$(cat)"
+if [[ -z "$selected_items" ]]; then
+  return 1
+fi
+
+_anyframe-action-insert-quoted "$@" "${(f)selected_items}"
+
+# Local Variables:
+# mode: Shell-Script
+# End:
+# vim: ft=zsh

--- a/anyframe-functions/widgets/anyframe-widget-insert-filename
+++ b/anyframe-functions/widgets/anyframe-widget-insert-filename
@@ -1,6 +1,6 @@
 anyframe-source-list-file "$BUFFER" \
   | anyframe-selector-auto \
-  | anyframe-action-insert
+  | anyframe-action-insert-quoted
 
 # Local Variables:
 # mode: Shell-Script


### PR DESCRIPTION
Quote special chars so that `foo* $bar.txt` is inserted as `foo\*\ \$bar.txt`.