### PR TITLE
Add feature to remove duplicated commands in history

### DIFF
--- a/anyframe-functions/sources/anyframe-source-history
+++ b/anyframe-functions/sources/anyframe-source-history
@@ -1,6 +1,7 @@
 # -r : reverses the order of the commands
 # -n : suppresses command numbers
-history -n -r 1
+# '!a[$0]++' : prints unique lines
+history -n -r 1 | awk '!a[$0]++'
 
 # Local Variables:
 # mode: Shell-Script


### PR DESCRIPTION
The anyframe-source-history script prints all commands in history (including duplicated commands).
I think this script should print unique commands, so I add filtering command.
The zshell has some features to ignore duplicated lines in history (hist\_ignore\_dups, and so on), but I think those features sometimes are [unnecessary](http://qiita.com/wada811/items/78b14181a4de0fd5b497).
