### PR TITLE
added vagrant widgets

### DIFF
--- a/anyframe-functions/sources/anyframe-source-vagrant-box-list
+++ b/anyframe-functions/sources/anyframe-source-vagrant-box-list
@@ -1,0 +1,8 @@
+# anyframe-source-vagrant-box-list
+
+vagrant box list
+
+# Local Variables:
+# mode: Shell-Script
+# End:
+# vim: ft=zsh

--- a/anyframe-functions/sources/anyframe-source-vagrant-global-status
+++ b/anyframe-functions/sources/anyframe-source-vagrant-global-status
@@ -1,0 +1,14 @@
+# require vagrant
+
+if type vagrant-global-status > /dev/null 2>&1; then
+  # faster than ` vagrant global-status`
+  # see -> https://github.com/monochromegane/vagrant-global-status
+  vagrant-global-status
+else
+  vagrant global-status | awk '/^[[:alnum:]]{7} /'
+fi
+
+# Local Variables:
+# mode: Shell-Script
+# End:
+# vim: ft=zsh

--- a/anyframe-functions/sources/anyframe-source-vagrant-list-commands
+++ b/anyframe-functions/sources/anyframe-source-vagrant-list-commands
@@ -1,0 +1,48 @@
+# Show vagrant command lists
+# Options
+# -a show all command lists [Default]
+# -b show command lists which take a box id.
+# -h show command lists which take a host id.
+
+_show_all_commands() {
+  vagrant list-commands
+}
+
+_show_host_commands() {
+  cat << EOL
+destroy         stops and deletes all traces of the vagrant machine
+halt            stops the vagrant machine
+provision       provisions the vagrant machine
+resume          resume a suspended vagrant machine
+ssh             connects to machine via SSH
+status          outputs status of the vagrant machine
+suspend         suspends the machine
+up              starts and provisions the vagrant environment
+EOL
+}
+
+_show_box_commands() {
+  cat << EOL
+remove          deletes the vagrant box
+repackage       repackages the vagrant box
+update          updates the vagrant box
+EOL
+}
+
+while getopts 'abh' option; do
+  case $option in
+    a)
+      _show_all_commands
+      ;;
+    b)
+      _show_box_commands
+      ;;
+    h)
+      _show_host_commands
+      ;;
+  esac
+done
+
+if [ $OPTIND -eq 1 ]; then
+  _show_all_commands
+fi

--- a/anyframe-functions/widgets/anyframe-widget-vagrant
+++ b/anyframe-functions/widgets/anyframe-widget-vagrant
@@ -1,0 +1,14 @@
+local command
+command=$(anyframe-source-vagrant-list-commands -h \
+             | anyframe-selector-auto \
+             | awk '{print $1}')
+
+anyframe-source-vagrant-global-status \
+  | anyframe-selector-auto \
+  | awk '{print $1}' \
+  | anyframe-action-execute vagrant ${command}
+
+# Local Variables:
+# mode: Shell-Script
+# End:
+# vim: ft=zsh

--- a/anyframe-functions/widgets/anyframe-widget-vagrant-box
+++ b/anyframe-functions/widgets/anyframe-widget-vagrant-box
@@ -1,0 +1,20 @@
+local command
+local options
+
+command=$(anyframe-source-vagrant-list-commands -b \
+             | anyframe-selector-auto \
+             | awk '{print $1}')
+
+if [[ "$command" -eq "update" ]]; then
+  options="--box"
+fi
+
+anyframe-source-vagrant-box-list \
+  | anyframe-selector-auto \
+  | awk '{print $1}' \
+  | anyframe-action-put vagrant box ${command} ${options}
+
+# Local Variables:
+# mode: Shell-Script
+# End:
+# vim: ft=zsh

--- a/anyframe-functions/widgets/anyframe-widget-vagrant-cdr
+++ b/anyframe-functions/widgets/anyframe-widget-vagrant-cdr
@@ -1,0 +1,9 @@
+anyframe-source-vagrant-global-status \
+  | anyframe-selector-auto \
+  | awk '{print $5}' \
+  | anyframe-action-execute cd
+
+# Local Variables:
+# mode: Shell-Script
+# End:
+# vim: ft=zsh


### PR DESCRIPTION
# summary

Added vagrant widgets.

There are some vagrant tools like this widgets.
- [vagrant-peco](https://github.com/monochromegane/vagrant-peco)
- [pecrant](https://github.com/gongo/pecrant)

But these plugins are too slow, because they use `vagrant global-status` to show host lists.

To show vagrant hosts, I pick `vagrant-global-status` command. (faster than `vagrant global-status` command which is included in vagrant installer. see
https://github.com/monochromegane/vagrant-global-status)
If `vagrant-global-status` is not installed, this plugin call `vagrant global-status`.
## anyframe-widget-vagrant

Plugin to execute `vagrant {command}  {hostname | id}`.

![2015-08-24 13 56 55](https://cloud.githubusercontent.com/assets/1096473/9433099/7421c7e0-4a68-11e5-830d-0471b3fd206f.png)

![2015-08-24 13 57 09](https://cloud.githubusercontent.com/assets/1096473/9433103/81d40fba-4a68-11e5-948c-0a60a7067f0b.png)

At first, I made `anyframe-widget-vagrant-hoge_command` files to execute a vagrant command, and added `bindkey` settings in .zshrc like below.

``` bash
bindkey '^v^u' anyframe-widget-vagrant-up
bindkey '^v^h' anyframe-widget-vagrant-halt
bindkey '^v^s' anyframe-widget-vagrant-suspend
bindkey '^v^j' anyframe-widget-vagrant-cdr
```

But selecting a command from "anyframe" is more convenient than above ways.
## anyframe-widget-vagrant-box

Plugin to execute `vagrant box {command}  {boxname}`.
As well as `anyframe-widget-vagrant`, you choose a command at first, and select a name to exec the command.

![2015-08-24 14 48 05](https://cloud.githubusercontent.com/assets/1096473/9433515/2cefadcc-4a6f-11e5-9157-695b4b2b690d.png)
## anyframe-widget-vagrant-cdr

Plugin to execute `cd {vagrant directory}`.

![_2015-08-24_14_49_09](https://cloud.githubusercontent.com/assets/1096473/9433546/68c8fd9e-4a6f-11e5-9297-2024859a73a3.png)
# etc

 You can also see [vagrantの各種コマンドを、anything風に操作できるようにする.(zsh+peco+anyframe)](http://qiita.com/kegamin/items/6dda8054ad9b6e170e5c)
