### PR TITLE
Fix no such option when anyframe-widget-cd-ghq-repository is exected

### DIFF
--- a/anyframe-functions/widgets/anyframe-widget-cd-ghq-repository
+++ b/anyframe-functions/widgets/anyframe-widget-cd-ghq-repository
@@ -1,6 +1,6 @@
 anyframe-source-ghq-repository \
   | anyframe-selector-auto \
-  | anyframe-action-execute cd --
+  | anyframe-action-execute cd
 
 # Local Variables:
 # mode: Shell-Script


### PR DESCRIPTION
Thank you for nice plugin.
I fix no such option when anyframe-widget-cd-ghq-repository is exected.

## Steps to reproduce

１. I set `anyframe-widget-cd-ghq-repository` settings like blow.

```
bindkey '^x^g' anyframe-widget-cd-ghq-repository
```

２. I execute `'^x^g'`. Below is log.

```
~/.ghq/github.com/takiy33/dotfiles %cd -- /Users/takiy33/.ghq/github.com/ayindi/polka-dot                              (git)-[master]
--: no such option
```
