### PR TITLE
Omit the path to ghq root in the list of ghq repos

### DIFF
--- a/anyframe-functions/sources/anyframe-source-ghq-repository
+++ b/anyframe-functions/sources/anyframe-source-ghq-repository
@@ -1,6 +1,6 @@
 # require ghq (https://github.com/motemen/ghq)
 
-ghq list --full-path
+ghq list
 
 # Local Variables:
 # mode: Shell-Script

--- a/anyframe-functions/widgets/anyframe-widget-cd-ghq-repository
+++ b/anyframe-functions/widgets/anyframe-widget-cd-ghq-repository
@@ -1,6 +1,6 @@
 anyframe-source-ghq-repository \
   | anyframe-selector-auto \
-  | anyframe-action-execute cd --
+  | anyframe-action-execute ghq look
 
 # Local Variables:
 # mode: Shell-Script


### PR DESCRIPTION
Omit the path to ghq root in the list of ghq repos.
Made it use `ghq look` to change directory.