### PR TITLE
Add anyframe-widget-insert-git-filename

### DIFF
--- a/anyframe-functions/sources/anyframe-source-git-ls-tree
+++ b/anyframe-functions/sources/anyframe-source-git-ls-tree
@@ -1,0 +1,8 @@
+# anyframe-source-git-ls-tree
+
+git ls-tree -r --name-only HEAD
+
+# Local Variables:
+# mode: Shell-Script
+# End:
+# vim: ft=zsh

--- a/anyframe-functions/widgets/anyframe-widget-insert-git-filename
+++ b/anyframe-functions/widgets/anyframe-widget-insert-git-filename
@@ -1,0 +1,8 @@
+anyframe-source-git-ls-tree \
+  | anyframe-selector-auto \
+  | anyframe-action-insert -q
+
+# Local Variables:
+# mode: Shell-Script
+# End:
+# vim: ft=zsh


### PR DESCRIPTION
Hi, it would be great if you would add `anyframe-widget-insert-git-filename` for listing files in git repository.

I personally use this function very often, and seems it's common and useful for fast traversal in a large git repository, regarding to [the README of fzf](https://github.com/junegunn/fzf#git-ls-tree-for-fast-traversal). So it would be nice to have as a common widget of anyframe.

Thanks!



