### PR TITLE
Added insertions of paths of files under Git

### DIFF
--- a/anyframe-functions/sources/anyframe-source-list-file
+++ b/anyframe-functions/sources/anyframe-source-list-file
@@ -18,7 +18,7 @@ if [[ -n "$buffer" ]]; then
   fi
 fi
 
-ls -- "$dir"
+( cd -- "$dir"; git rev-parse 2>/dev/null && git ls-files -co --exclude-standard || ls )
 
 # Local Variables:
 # mode: Shell-Script


### PR DESCRIPTION
Added insertions of paths of files under Git. The source `list-file`
shows `git ls-files` if the working directory is under Git.