### PR TITLE
make anyframe use builtin commands when available

### DIFF
--- a/anyframe-functions/widgets/anyframe-widget-cd-ghq-repository
+++ b/anyframe-functions/widgets/anyframe-widget-cd-ghq-repository
@@ -1,6 +1,6 @@
 anyframe-source-ghq-repository \
   | anyframe-selector-auto \
-  | anyframe-action-execute cd --
+  | anyframe-action-execute builtin cd --
 
 # Local Variables:
 # mode: Shell-Script

--- a/anyframe-functions/widgets/anyframe-widget-cdr
+++ b/anyframe-functions/widgets/anyframe-widget-cdr
@@ -1,6 +1,6 @@
 anyframe-source-cdr \
   | anyframe-selector-auto \
-  | anyframe-action-execute cd --
+  | anyframe-action-execute builtin cd --
 
 # Local Variables:
 # mode: Shell-Script

--- a/anyframe-functions/widgets/anyframe-widget-kill
+++ b/anyframe-functions/widgets/anyframe-widget-kill
@@ -1,7 +1,7 @@
 anyframe-source-process \
   | anyframe-selector-auto \
   | awk '{print $1}' \
-  | anyframe-action-execute kill
+  | anyframe-action-execute builtin kill
 
 # Local Variables:
 # mode: Shell-Script


### PR DESCRIPTION
When I used [enhancd](https://github.com/b4b4r07/enhancd), anyframe tried changing the directory with cd of enhancd. And they conflicted because enhancd did not accepted argments '--' , which is used in anyframe cd widgets.
So I made anyframe use builtin commands when available(this time, cd and kill).