### PR TITLE
Add Fig as an installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ autoload -Uz anyframe-init
 anyframe-init
 ```
 
+### Fig
+
+Install `anyframe` with [Fig](https://fig.io) in just one click.
+
+<a href="https://fig.io/plugins/other/anyframe_mollifier" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 ### Installing using Antigen
 If you use [Antigen](https://github.com/zsh-users/antigen), add the following line to your .zshrc:
 


### PR DESCRIPTION
We recently listed `anyframe` on [Fig Plugin Store](https://fig.io/plugins), so we'd love to have Fig displayed as a download method on your readme. Thanks so much and please let me know if you have any questions!